### PR TITLE
Perform conflict resolution on all resopairs

### DIFF
--- a/plugins/asas/speedbased.py
+++ b/plugins/asas/speedbased.py
@@ -382,14 +382,6 @@ class SpeedBased(ConflictResolution):
                 changeactive[idx1] = changeactive.get(idx1, False)
                 # If conflict is solved, remove it from the resopairs list.
                 delpairs.add(conflict)
-                # Reset is_leading flag.
-                if idx2 >= 0:
-                    self.is_leading[idx1].pop(intruder.id[idx2])
-                else:
-                    # Check which aircraft are deleted and remove those.
-                    to_pop = [acid for acid in self.is_leading[idx1].keys() if acid not in ownship.id]
-                    for acid in to_pop:
-                        self.is_leading[idx1].pop(acid)
 
         for idx, active in changeactive.items():
             # Loop a second time: this is to avoid that ASAS resolution is
@@ -407,6 +399,15 @@ class SpeedBased(ConflictResolution):
 
         # Remove pairs from the list that are past CPA or have deleted aircraft.
         self.resopairs -= delpairs
+
+        # Remove all combinations not in resopairs from is_leading flag.
+        allowed_combinations = {idx: [] for idx in range(ownship.ntraf)}
+        for pair in self.resopairs:
+            allowed_combinations[ownship.id.index(pair[0])].append(pair[1])
+        for idx in range(ownship.ntraf):
+            to_pop = [acid for acid in self.is_leading[idx].keys() if acid not in allowed_combinations[idx]]
+            for acid in to_pop:
+                self.is_leading[idx].pop(acid)
 
     def detect(self, pairs, ownship, intruder) -> dict:
         """

--- a/plugins/urban_area.py
+++ b/plugins/urban_area.py
@@ -219,6 +219,7 @@ class Area(Entity):
             [lospairs_new.remove(pair) for pair in ignore_lospair if pair in lospairs_new]
 
             # if lospairs_new:
+            #     # Use this for debugging reso algo.
             #     print('LoS found:', lospairs_new)
             #     print()
 

--- a/utils/analytical.py
+++ b/utils/analytical.py
@@ -85,30 +85,32 @@ class AnalyticalModel:
         # Conflicts --------
         # Crossing flows.
         vrel = 2 * self.speed * np.sin(np.deg2rad(90) / 2)
-        c_inst_nr_crossing = (4 * np.power(self.n_inst / 4, 2) * self.s_h * vrel * self.t_l
+        c_inst_nr_crossing = (4 * np.power(self.n_inst / 4, 2) * 2 * self.s_h * vrel * self.t_l
                               / self.urban_grid.area)
 
         # Self interaction with departing traffic. Same as crossing, but in xz-plane.
+        # TODO: Add depth (equivalent to altitude layers).
         alt_to_climb = self.cruise_alt - self.departure_alt
         time_to_climb = alt_to_climb / self.vs
         n_inst_departing = self.departure_rate * time_to_climb
         n_inst_cruise = self.n_inst - n_inst_departing
-        area = alt_to_climb * np.sqrt(self.urban_grid.area)
-        c_inst_nr_departing = n_inst_departing * n_inst_cruise * self.s_v * self.vs * self.t_l / area
+        xz_area = alt_to_climb * np.sqrt(self.urban_grid.area)
+        # c_inst_nr_departing = n_inst_departing * n_inst_cruise * self.s_v * self.vs * self.t_l / xz_area
+        c_inst_nr_departing = 0 * n_inst_departing
 
         c_inst_nr = c_inst_nr_crossing + c_inst_nr_departing
 
         # LoS ---------
-        los_inst_nr_crossing = (4 * np.power(self.n_inst / 4, 2) * np.pi * np.power(self.s_h / 2, 2)
+        # los_inst_nr_crossing = (4 * np.power(self.n_inst / 4, 2) * np.pi * np.power(self.s_h, 2)
+        #                         / self.urban_grid.area)
+        los_inst_nr_crossing = (np.power(self.n_inst, 2) * np.pi * np.power(self.s_h, 2)
                                 / self.urban_grid.area)
 
-        # Self interaction with departing traffic. Same as crossing, but in xz-plane.
-        alt_to_climb = self.cruise_alt - self.departure_alt
-        time_to_climb = alt_to_climb / self.vs
-        n_inst_departing = self.departure_rate * time_to_climb
-        n_inst_cruise = self.n_inst - n_inst_departing
-        area = alt_to_climb * np.sqrt(self.urban_grid.area)
-        los_inst_nr_departing = n_inst_departing * n_inst_cruise * np.pi * np.power(self.s_v / 2, 2) / area
+
+        # Self interaction with departing traffic.
+        # TODO: Add depth (equivalent to altitude layers).
+        # los_inst_nr_departing = n_inst_departing * n_inst_cruise * self.s_v * self.s_h / xz_area
+        los_inst_nr_departing = 0 * n_inst_departing
 
         los_inst_nr = los_inst_nr_crossing + los_inst_nr_departing
 

--- a/utils/analytical.py
+++ b/utils/analytical.py
@@ -12,7 +12,7 @@ import pickle as pkl
 from plugins.urban import UrbanGrid
 from pathlib import Path
 from scn_reader import plot_flow_rates
-from bluesky.tools.aero import fpm
+from bluesky.tools.aero import fpm, ft
 
 # VS depends on the steepness used in autopilot.py, adjust accordingly.
 VS = 194. * fpm
@@ -31,12 +31,11 @@ class AnalyticalModel:
         self.speed = speed
         self.vs = vs
         self.s_h = s_h
-        self.s_v = s_v
+        self.s_v = s_v * ft  # m
         self.t_l = t_l
 
-        self.cruise_alt = 50.  # ft
-        self.departure_alt = 0.  # ft
-        self.t_X = self.s_h * np.sqrt(2) / self.speed  # Time to cross an intersection [s]
+        self.cruise_alt = 50. * ft  # m
+        self.departure_alt = 0. * ft  # m
         self.avg_duration = self.urban_grid.avg_route_length / self.speed
 
         # Sanity check.
@@ -166,6 +165,13 @@ class AnalyticalModel:
 
         # Delay model.
         for node in self.urban_grid.all_nodes:
+            if node in self.urban_grid.od_nodes:
+                # Time to merge an altitude layer [s].
+                # TODO: does the s_v corner of the disc play a role here?
+                t_x = self.s_h / self.speed
+            else:
+                # Time to cross an intersection [s]. Change sqrt(2) if angle between airways is not 90 degrees.
+                t_x = self.s_h * np.sqrt(2) / self.speed
             node_flows = flow_df.iloc[
                 flow_df.index.get_level_values('via') == node
             ].copy()
@@ -178,15 +184,15 @@ class AnalyticalModel:
                 raise ValueError(f'Intersection with {len(from_nodes)} directions found!\n', node_flows)
 
             total_q = node_flows.sum()
-            total_y = total_q * self.t_X
+            total_y = total_q * t_x
             total_stochastic_delay = total_y * total_y / (2 * total_q * (1 - total_y))
             for (i, j) in [(1, 0), (0, 1)]:
                 # General delay.
                 q_g = node_flows.iloc[i].squeeze()
                 q_r = node_flows.iloc[j].squeeze()
-                lambda_u = 1 - self.t_X * q_r
+                lambda_u = 1 - t_x * q_r
                 c_u = 1 / q_r
-                y = q_g * self.t_X
+                y = q_g * t_x
                 general_delay = c_u * np.power(1 - lambda_u, 2) / (2 * (1 - y))
 
                 # Stochastic delay.

--- a/utils/analytical.py
+++ b/utils/analytical.py
@@ -36,7 +36,7 @@ class AnalyticalModel:
 
         self.cruise_alt = 50.  # ft
         self.departure_alt = 0.  # ft
-        self.t_X = self.s_h * 1.05 / self.speed  # Time to cross an intersection [s]
+        self.t_X = self.s_h * np.sqrt(2) / self.speed  # Time to cross an intersection [s]
         self.avg_duration = self.urban_grid.avg_route_length / self.speed
 
         # Sanity check.
@@ -208,7 +208,7 @@ class AnalyticalModel:
         mean_v = pd.DataFrame(np.ones(self.n_inst.shape) * self.speed, index=self.n_inst)
 
         # Calculate nr case (as check).
-        max_ni_per_section = self.urban_grid.grid_height / (self.s_h * 1.05)
+        max_ni_per_section = self.urban_grid.grid_height / self.s_h
         nr_duration_per_section = pd.DataFrame(self.urban_grid.grid_height / self.speed,
                                                index=self.delays.index, columns=self.delays.columns)
         nr_duration_per_section = nr_duration_per_section[

--- a/utils/log_reader.py
+++ b/utils/log_reader.py
@@ -252,7 +252,7 @@ def load_analytical_model(result: dict, scn_folder: Path = SCN_FOLDER) -> Tuple[
         s_h = all_s_h[0]
         s_v = all_s_v[0]
         t_l = all_t_l[0]
-    ana_model = AnalyticalModel(urban_grid, max_value=max_val, accuracy=25,
+    ana_model = AnalyticalModel(urban_grid, max_value=max_val * 1.1, accuracy=25,
                                 duration=duration, speed=speed, s_h=s_h, s_v=s_v, t_l=t_l)
     return urban_grid, ana_model
 
@@ -440,7 +440,7 @@ def save_data(data: dict, name: str, output_dir: Path = OUTPUT_FOLDER) -> pd.Dat
 
 
 if __name__ == '__main__':
-    use_pkl = False
+    use_pkl = True
 
     if use_pkl:
         res_pkl = Path(r'C:\Users\michi\OneDrive\Documenten\GitHub\bluesky\output\RESULT\batch_extensive_run_NR.pkl')

--- a/utils/log_reader.py
+++ b/utils/log_reader.py
@@ -239,7 +239,7 @@ def load_analytical_model(result: dict, scn_folder: Path = SCN_FOLDER) -> Tuple[
     # Extract parameters for analytical model.
     all_runs = [run for run in result.keys() if run != 'name']
     all_speeds = [result[run]['scn']['speed'] for run in all_runs]
-    all_s_h = [result[run]['scn']['s_h'] * np.sqrt(2) for run in all_runs]
+    all_s_h = [result[run]['scn']['s_h'] for run in all_runs]
     all_s_v = [result[run]['scn']['s_v'] for run in all_runs]
     all_t_l = [result[run]['scn']['t_l'] for run in all_runs]
     max_val = max([result[run]['scn']['n_inst'] for run in all_runs])
@@ -443,7 +443,7 @@ if __name__ == '__main__':
     use_pkl = False
 
     if use_pkl:
-        res_pkl = Path(r'C:\Users\michi\OneDrive\Documenten\GitHub\bluesky\output\RESULT\batch_stable_flag_NR.pkl')
+        res_pkl = Path(r'C:\Users\michi\OneDrive\Documenten\GitHub\bluesky\output\RESULT\batch_extensive_run_NR.pkl')
         with open(res_pkl, 'rb') as f:
             res = pkl.load(f)
     else:

--- a/utils/log_reader.py
+++ b/utils/log_reader.py
@@ -359,7 +359,7 @@ def plot_result(result: dict, ana_model: AnalyticalModel) -> Tuple[List[plt.Figu
     conf_axs[0].plot(ana_model.n_inst, ana_model.c_inst_nr, color='blue', label='NR Model')
     conf_axs[0].plot(ana_model.n_inst, ana_model.c_inst_wr_fitted, color='coral', linestyle='--', label='WR Fitted')
     conf_axs[1].set_ylabel('Inst. no. of los [-]')
-    conf_axs[1].plot(ana_model.n_inst, ana_model.los_inst_nr, color='blue', label='NR Model')
+    # conf_axs[1].plot(ana_model.n_inst, ana_model.los_inst_nr, color='blue', label='NR Model')
     conf_axs[1].plot(ana_model.n_inst, ana_model.los_inst_nr_fitted, color='lightblue', linestyle='--',
                      label=rf'NR Fitted, $\bar{{t_{{los,NR}}}}={ana_model.avg_los_duration_nr:.1f}$s')
     conf_axs[1].plot(ana_model.n_inst, ana_model.los_inst_wr, color='coral', linestyle='--',
@@ -443,7 +443,7 @@ if __name__ == '__main__':
     use_pkl = True
 
     if use_pkl:
-        res_pkl = Path(r'C:\Users\michi\OneDrive\Documenten\GitHub\bluesky\output\RESULT\batch_extensive_run_NR.pkl')
+        res_pkl = Path(r'C:\Users\michi\OneDrive\Documenten\GitHub\bluesky\output\RESULT\batch_patch_is_leading_NR.pkl')
         with open(res_pkl, 'rb') as f:
             res = pkl.load(f)
     else:

--- a/utils/quick_log_reader.py
+++ b/utils/quick_log_reader.py
@@ -21,7 +21,13 @@ else:
         data[fname] = pd.read_csv(Path(fpath), comment='#', skipinitialspace=True)
         print(data[fname].head())
         try:
+            # CONFLOGS.
             plt.plot(data[fname]['t'] - data[fname]['t'][0], data[fname]['ntotal_los'], label=fname)
+        except KeyError:
+            pass
+        try:
+            # FLSTLOGS.
+            print(f'Mean {fname}: {np.mean(data[fname]["dist3D"] / data[fname]["flight_time"]):.2f}m/s')
         except KeyError:
             pass
     plt.legend()

--- a/utils/scenario_generator.py
+++ b/utils/scenario_generator.py
@@ -220,9 +220,10 @@ class ScenarioGenerator:
                         self.urban_grid.max_lat + 1, self.urban_grid.max_lon + 1]
                 f.write(f'{self.tim2txt(0)}>AREA {bbox[0]} {bbox[1]} {bbox[2]} {bbox[3]}\n\n')
 
-                # Set dt of fms to 0
-                f.write('# Set dt of FMS to 0\n')
-                f.write(f'{self.tim2txt(0)}>DT FMS 0.001\n\n')
+                # Set dt of fms and asas to 0
+                f.write('# Set dt of FMS and ASAS to 0\n')
+                f.write(f'{self.tim2txt(0)}>DT FMS 0.001\n')
+                f.write(f'{self.tim2txt(0)}>DT ASAS 0.001\n\n')
 
                 # Create aircraft.
                 f.write('# Create aircraft.\n')
@@ -305,16 +306,16 @@ class ScenarioGenerator:
 
 
 if __name__ == '__main__':
-    N_INST = np.array([10, 20, 30, 40, 50, 60, 70])
-    REPETITIONS = 10
+    N_INST = np.array([50, 100, 175, 250, 350])
+    REPETITIONS = 1
     SPEED = 10.
     BUILD_UP_DURATION = 900.
     EXPERIMENT_DURATION = 2700.
     COOL_DOWN_DURATION = 900.
     DURATION = (BUILD_UP_DURATION, EXPERIMENT_DURATION, COOL_DOWN_DURATION)
-    PREFIX = 'extensive_run'
+    PREFIX = 'big_grid'
 
-    N_ROWS = 7
+    N_ROWS = 23
     N_COLS = N_ROWS
     GRID_HEIGHT = 200.  # m
     GRID_WIDTH = GRID_HEIGHT


### PR DESCRIPTION
- Perform conflict resolution on all resopairs. As such, when the leader in a conflict accelerates, the following vehicle can accelerate as well, without having to wait for the CPA (after which resume_nav is activated). 
- Add reaction time to conflict resolution, to let aircraft close the gap quicker.
- Various updates to analytical model.